### PR TITLE
fix: ignore prefix2

### DIFF
--- a/nested.tmux
+++ b/nested.tmux
@@ -27,6 +27,7 @@ tmux bind -n "$down_keybind" \
 "set-environment \"$NESTED_COUNTER_ENV_NAME\" 1 ; "\
 "set key-table \"$NESTED_INACTIVE_TABLE_NAME\" ; "\
 'set prefix None ; '\
+'set prefix2 None ; '\
 "set \"$status_style_option\" \"$inactive_status_style\""
 tmux bind -T "$NESTED_INACTIVE_TABLE_NAME" "$down_keybind" \
 "run-shell 'tmux set-environment \"$NESTED_COUNTER_ENV_NAME\" \$(( \$(tmux show-environment \"$NESTED_COUNTER_ENV_NAME\" | cut -d = -f 2) + 1 ))' ; "\
@@ -38,7 +39,7 @@ tmux bind -n "$up_keybind" \
 tmux bind -T "$NESTED_INACTIVE_TABLE_NAME" "$up_keybind" \
 "run-shell 'tmux set-environment \"$NESTED_COUNTER_ENV_NAME\" \$(( \$(tmux show-environment \"$NESTED_COUNTER_ENV_NAME\" | cut -d = -f 2) - 1 ))' ; "\
 "if-shell '[ \"\$(tmux show-environment \"$NESTED_COUNTER_ENV_NAME\" | cut -d = -f 2)\" -eq 0 ]' "\
-"'set-environment -u \"$NESTED_COUNTER_ENV_NAME\" ; set -u prefix ; set -u key-table ; set -u \"$status_style_option\"' "\
+"'set-environment -u \"$NESTED_COUNTER_ENV_NAME\" ; set -u prefix ; set -u prefix2 ; set -u key-table ; set -u \"$status_style_option\"' "\
 "'send-keys \"$up_keybind\"'"
 
 # Up recursive: enable all tmux instances recursively
@@ -50,6 +51,7 @@ tmux bind -T "$NESTED_INACTIVE_TABLE_NAME" "$up_recursive_keybind" \
 "set-environment -u \"$NESTED_COUNTER_ENV_NAME\" ; "\
 'set -u key-table ; '\
 'set -u prefix ; '\
+'set -u prefix2 ; '\
 "set -u \"$status_style_option\""
 
 # Note: `$(tmux show-environment NESTED_COUNTER | cut -d = -f 2)` is the simplest way to retrieve the


### PR DESCRIPTION
When disabling outer tmux shell prefix2 was still captured the outer shell this change corrects that.