### PR TITLE
feat: update status style dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,13 @@ set -g @matryoshka_down_keybind 'M-d'
 set -g @matryoshka_up_keybind 'M-u'
 # keybind to recursively enable all tmux instances
 set -g @matryoshka_up_recursive_keybind 'M-U'
-# status style of inactive tmux
-set -g @matryoshka_inactive_status_style 'fg=colour245,bg=colour238'
+
+# to set the inactive status style, you can choose either to provide a fixed value...
+set -g @matryoshka_inactive_status_style_strategy 'assignment'
+set -g @matryoshka_inactive_status_style 'bg=colour238,fg=colour245'
+# ...or patch the existing status style with sed substitutions
+set -g @matryoshka_inactive_status_style_strategy 'sed'
+set -g @matryoshka_inactive_status_style 's/green/colour238/g; s/black/colour245/g'
 
 # name of the option for the style of the status line
 # set if you rely on something other than the default 'status-style' option for it

--- a/matryoshka.tmux
+++ b/matryoshka.tmux
@@ -2,7 +2,7 @@
 
 set -eu
 
-# >>> Keybinds and default values
+# >>> Configuration options and default values
 down_keybind="$(tmux show-option -gqv @matryoshka_down_keybind)"
 if [ -z "$down_keybind" ]; then down_keybind='F1'; fi
 
@@ -12,23 +12,34 @@ if [ -z "$up_keybind" ]; then up_keybind='F2'; fi
 up_recursive_keybind="$(tmux show-option -gqv @matryoshka_up_recursive_keybind)"
 if [ -z "$up_recursive_keybind" ]; then up_recursive_keybind='F3'; fi
 
+inactive_status_style_strategy="$(tmux show-option -gqv @matryoshka_inactive_status_style_strategy)"
+if [ -z "$inactive_status_style_strategy" ]; then inactive_status_style_strategy='assignment'; fi
+
 inactive_status_style="$(tmux show-option -gqv @matryoshka_inactive_status_style)"
-if [ -z "$inactive_status_style" ]; then inactive_status_style='fg=colour245,bg=colour238'; fi
+if [ -z "$inactive_status_style" ]; then inactive_status_style='bg=colour238,fg=colour245'; fi
 
 status_style_option="$(tmux show-option -gqv @matryoshka_status_style_option)"
 if [ -z "$status_style_option" ]; then status_style_option='status-style'; fi
-# <<< Keybinds and default values
+# <<< Configuration options and default values
 
 MATRYOSHKA_COUNTER_ENV_NAME='MATRYOSHKA_COUNTER'
 MATRYOSHKA_INACTIVE_TABLE_NAME='matryoshka-inactive'
 
 # Down: disable the outer-most active tmux
+if [ "$inactive_status_style_strategy" = 'assignment' ]; then
+    status_style_update="set-option \"$status_style_option\" \"$inactive_status_style\""
+elif [ "$inactive_status_style_strategy" = 'sed' ]; then
+    status_style_update="run-shell 'tmux set-option \"$status_style_option\" \"\$(tmux show-option -gqv \"$status_style_option\" | sed \"$inactive_status_style\")\"'"
+else
+    >&2 echo "Error: unknown inactive status style strategy '$inactive_status_style_strategy'"
+    exit 1
+fi
 tmux bind -n "$down_keybind" \
 "set-environment \"$MATRYOSHKA_COUNTER_ENV_NAME\" 1 ; "\
 "set key-table \"$MATRYOSHKA_INACTIVE_TABLE_NAME\" ; "\
 'set prefix None ; '\
 'set prefix2 None ; '\
-"set \"$status_style_option\" \"$inactive_status_style\""
+"$status_style_update"
 tmux bind -T "$MATRYOSHKA_INACTIVE_TABLE_NAME" "$down_keybind" \
 "run-shell 'tmux set-environment \"$MATRYOSHKA_COUNTER_ENV_NAME\" \$(( \$(tmux show-environment \"$MATRYOSHKA_COUNTER_ENV_NAME\" | cut -d = -f 2) + 1 ))' ; "\
 "send-keys \"$down_keybind\""


### PR DESCRIPTION
Currently, tmux-matryoshka only allows you to specify a fixed status style for when entering inactive mode.

A common use case is to have the inactive status style closely resemble the active one, with perhaps subtle differences, like using different colors to indicate the inactive state.

While it’s easy to achieve this with fixed values in simple status styles, users with more complex styles may need to duplicate the entire string in their configuration as a large constant, which can be cumbersome. Furthermore, if the status style changes dynamically during the session, it becomes impossible to set up matryoshka to accommodate this color-switching pattern.

This PR introduces a new option, `matryoshka_inactive_status_style_strategy`, which can have two values: `assignment` (the original behavior) and `sed`. The `sed` option allows you to define sed substitutions for the current status style when deactivating the tmux instance, thus resolving the issues described above.

Reimplements #3.